### PR TITLE
Buffer sizes changed, Qos added

### DIFF
--- a/src/xsens_mti_ros2_driver/include/xdacallback.h
+++ b/src/xsens_mti_ros2_driver/include/xdacallback.h
@@ -48,7 +48,7 @@ typedef std::pair<rclcpp::Time, XsDataPacket> RosXsDataPacket;
 class XdaCallback : public XsCallback
 {
 public:
-	XdaCallback(rclcpp::Node::SharedPtr node, size_t maxBufferSize = 5);
+	XdaCallback(rclcpp::Node::SharedPtr node, size_t maxBufferSize = 1000);
 	virtual ~XdaCallback() throw();
 
 	RosXsDataPacket next(const std::chrono::milliseconds &timeout);

--- a/src/xsens_mti_ros2_driver/src/messagepublishers/accelerationhrpublisher.h
+++ b/src/xsens_mti_ros2_driver/src/messagepublishers/accelerationhrpublisher.h
@@ -42,10 +42,10 @@ struct AccelerationHRPublisher : public PacketCallback
 
     AccelerationHRPublisher(rclcpp::Node::SharedPtr node)
     {
-        int pub_queue_size = 5;
+        int pub_queue_size = 100;
         node->get_parameter("publisher_queue_size", pub_queue_size);
         rclcpp::QoS qos = rclcpp::SensorDataQoS();
-        qos.keep_last(pub_queue_size); 
+        qos.keep_last(pub_queue_size);
         pub = node->create_publisher<geometry_msgs::msg::Vector3Stamped>("/imu/acceleration_hr", qos);
         node->get_parameter("frame_id", frame_id);
     }

--- a/src/xsens_mti_ros2_driver/src/messagepublishers/angularvelocityhrpublisher.h
+++ b/src/xsens_mti_ros2_driver/src/messagepublishers/angularvelocityhrpublisher.h
@@ -42,7 +42,7 @@ struct AngularVelocityHRPublisher : public PacketCallback
 
     AngularVelocityHRPublisher(rclcpp::Node::SharedPtr node)
     {
-        int pub_queue_size = 5;
+        int pub_queue_size = 100;
         node->get_parameter("publisher_queue_size", pub_queue_size);
         rclcpp::QoS qos = rclcpp::SensorDataQoS();
         qos.keep_last(pub_queue_size); 

--- a/src/xsens_mti_ros2_driver/src/messagepublishers/imuhrpublisher.h
+++ b/src/xsens_mti_ros2_driver/src/messagepublishers/imuhrpublisher.h
@@ -59,10 +59,10 @@ struct ImuHRPublisher : public PacketCallback, PublisherHelperFunctions
         node->declare_parameter("angular_velocity_stddev", variance);
         node->declare_parameter("linear_acceleration_stddev", variance);
 
-        int pub_queue_size = 5;
+        int pub_queue_size = 100;
         node->get_parameter("publisher_queue_size", pub_queue_size);
         rclcpp::QoS qos = rclcpp::SensorDataQoS();
-        qos.keep_last(pub_queue_size); 
+        qos.keep_last(pub_queue_size);
         pub = node->create_publisher<sensor_msgs::msg::Imu>("/imu/data", qos);
 
         // REP 145: Conventions for IMU Sensor Drivers (http://www.ros.org/reps/rep-0145.html)

--- a/src/xsens_mti_ros2_driver/src/messagepublishers/imupublisher.h
+++ b/src/xsens_mti_ros2_driver/src/messagepublishers/imupublisher.h
@@ -54,9 +54,11 @@ struct ImuPublisher : public PacketCallback, PublisherHelperFunctions
         node->declare_parameter("angular_velocity_stddev", variance);
         node->declare_parameter("linear_acceleration_stddev", variance);
 
-        int pub_queue_size = 5;
+        int pub_queue_size = 100;
         node->get_parameter("publisher_queue_size", pub_queue_size);
-        pub = node->create_publisher<sensor_msgs::msg::Imu>("/imu/data", pub_queue_size);
+        rclcpp::QoS qos = rclcpp::SensorDataQoS();
+        qos.keep_last(pub_queue_size);
+        pub = node->create_publisher<sensor_msgs::msg::Imu>("/imu/data", qos);
 
         // REP 145: Conventions for IMU Sensor Drivers (http://www.ros.org/reps/rep-0145.html)
         variance_from_stddev_param("orientation_stddev", orientation_variance, node);


### PR DESCRIPTION
Publisher queue size and driver buffer size was increased for preventing data loss when the higher data rate publishing is used.

Additionally the QoS profile has been added to `imupublisher.h` as well.