### PR TITLE
NL-2326 Fix/missing imu watchdog messages

### DIFF
--- a/src/xsens_mti_ros2_driver/src/main.cpp
+++ b/src/xsens_mti_ros2_driver/src/main.cpp
@@ -107,27 +107,27 @@ class ImuNodeWatchdog {
 
     const double time_since_last_info_msg = current_time - last_info_message_time_;
     if (time_since_last_info_msg > thres0_) {
-      std::cerr << "IMU-WATCHDOG: IMU healthy (" << current_time << ")\n";
+      RCLCPP_INFO(node_->get_logger(), ("IMU-WATCHDOG: IMU healthy (" + std::to_string(current_time) + ")").c_str());
       last_info_message_time_ = current_time;
     }
 
     if (time_since_last_msg > thres1_) {
-      std::cerr << "IMU-WATCHDOG: IMU driver fault detected! No messages received for "
-                << time_since_last_msg << " seconds. Restarting driver...\n";
+      RCLCPP_INFO(node_->get_logger(), ("IMU-WATCHDOG: IMU driver fault detected! No messages received for "
+            + std::to_string(time_since_last_msg) + " seconds. Restarting driver...").c_str());
       resetAndInitXdaInterface();
 
       if (resetAndInitXdaInterface()) {
-        std::cerr << "XdaInterface successfully reinitialized.\n";
+        RCLCPP_INFO(node_->get_logger(), "XdaInterface successfully reinitialized.");
       } else {
         driver_fault_counter_++;
-        std::cerr << "Failed to reinitialize XdaInterface. Driver fault counter: "
-                  << driver_fault_counter_ << "\n";
+        RCLCPP_ERROR(node_->get_logger(), ("Failed to reinitialize XdaInterface. Driver fault counter: " +
+                  std::to_string(driver_fault_counter_)).c_str());
       }
     }
 
     if (!published_driver_error_ && time_since_last_msg > thres2_) {
-      std::cerr << "IMU-WATCHDOG: IMU driver fault detected! No messages received for "
-                << time_since_last_msg << " seconds. Sending error message to GUI...\n";
+      RCLCPP_ERROR(node_->get_logger(), ("IMU-WATCHDOG: IMU driver fault detected! No messages received for "
+            + std::to_string(time_since_last_msg) + " seconds. Sending error message to GUI...").c_str());
 
       diagnostic_msgs::msg::DiagnosticStatus status;
       status.name = "IMU Driver Fault";
@@ -165,7 +165,7 @@ class ImuNodeWatchdog {
   }
 
   ~ImuNodeWatchdog() {
-    std::cerr << "Shutting down ImuNodeWatchdog\n";
+    RCLCPP_INFO(node_->get_logger(), "Shutting down ImuNodeWatchdog");
     xdaInterface_.reset();
     rclcpp::shutdown();
   }
@@ -183,7 +183,7 @@ int main(int argc, char *argv[]) {
   // called from within this thread (the main thread in this case).
   rclcpp::executors::SingleThreadedExecutor exec;
   auto node = std::make_shared<rclcpp::Node>("xsens_driver");
-  
+
   ImuNodeWatchdog watchdog(node);
 
   exec.add_node(node);


### PR DESCRIPTION
This attempts to fix the missing IMU watchdog messages by changing from std::cerr to ros2 logger. I think there is something strange happening inside the driver that is modifying how standard cout and cerr are handled.

Messages before:
```
[xsens_mti_node-1] [INFO] [1755093402.317572397] [xsens_mti_node]: Since the HighRate Data is enabled, Sensor baudrate forcely configured to 2000000.
[xsens_mti_node-1] [INFO] [1755093402.367715352] [xsens_mti_node]: Rosnode time_option is sample time fine from MTi
[xsens_mti_node-1] [INFO] [1755093402.379894479] [xsens_mti_node]: Measuring ..
[xsens_mti_node-1] [INFO] [1755093402.444306838] [xsens_mti_node]: Manual Gyro Bias Estimation is disabled.
^C[WARNING] [launch]: user interrupted with ctrl-c (SIGINT)
[xsens_mti_node-1] [INFO] [1755093514.894246496] [rclcpp]: signal_handler(signum=2)
[xsens_mti_node-1] [INFO] [1755093514.896170749] [xsens_mti_node]: Cleaning up ...
```

Messages after:
```
[xsens_mti_node-1] [INFO] [1755093682.123880603] [xsens_mti_node]: Since the HighRate Data is enabled, Sensor baudrate forcely configured to 2000000.
[xsens_mti_node-1] [INFO] [1755093682.174009423] [xsens_mti_node]: Rosnode time_option is sample time fine from MTi
[xsens_mti_node-1] [INFO] [1755093682.185217148] [xsens_mti_node]: Measuring ..
[xsens_mti_node-1] [INFO] [1755093682.250310893] [xsens_mti_node]: Manual Gyro Bias Estimation is disabled.
[xsens_mti_node-1] [INFO] [1755093682.352647827] [xsens_mti_node]: IMU-WATCHDOG: IMU healthy (1755093682.352634)
[xsens_mti_node-1] [INFO] [1755093692.352807451] [xsens_mti_node]: IMU-WATCHDOG: IMU healthy (1755093692.352793)
[xsens_mti_node-1] [INFO] [1755093702.352985093] [xsens_mti_node]: IMU-WATCHDOG: IMU healthy (1755093702.352970)
^C[WARNING] [launch]: user interrupted with ctrl-c (SIGINT)
[xsens_mti_node-1] [INFO] [1755093707.839535890] [rclcpp]: signal_handler(signum=2)
[xsens_mti_node-1] [INFO] [1755093707.842777713] [xsens_mti_node]: Shutting down ImuNodeWatchdog
[xsens_mti_node-1] [INFO] [1755093707.842806610] [xsens_mti_node]: Cleaning up ...
```